### PR TITLE
Fix capture module imports

### DIFF
--- a/core/capture.py
+++ b/core/capture.py
@@ -2,6 +2,7 @@
 import platform
 import subprocess
 import os
+import shutil
 from core.utils import print_progress
 
 class HandshakeCapturer:


### PR DESCRIPTION
## Summary
- add missing `shutil` import in `core/capture.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- run capture logic with patched `subprocess.run` to ensure no NameError

------
https://chatgpt.com/codex/tasks/task_e_684075abdbf4832dabef254828815348